### PR TITLE
New Custom Function

### DIFF
--- a/Shared Functions Library/PRISM Functions Library.vbs
+++ b/Shared Functions Library/PRISM Functions Library.vbs
@@ -473,3 +473,8 @@ Function write_new_line_in_PRISM_case_note(variable)							'DEPRECIATED 03/10/20
 	call write_variable_in_CAAD(variable)
 End function
 
+FUNCTION write_value_and_transmit(input_value, PRISM_row, PRISM_col)
+	EMWriteScreen input_value, PRISM_row, PRISM_col
+	transmit
+END FUNCTION
+


### PR DESCRIPTION
Added Custom Function. write_value_and_transmit enables the script writer to take two lines and merge them into one. SO, instead of an 

EMWriteScreen value, row, col
transmit

The user can CALL write_value_and_transmit(value, row, col).